### PR TITLE
chore: rename package to travian-elephant-finder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "travian-elephant",
+  "name": "travian-elephant-finder",
   "version": "0.0.4",
   "dependencies": {
     "axios": "^1.7.9",


### PR DESCRIPTION
## Summary

Rename `package.json` `name` field from `travian-elephant` to `travian-elephant-finder` to match the GitHub repository name.

Only one occurrence found outside node_modules — the `name` field in `package.json`.