### PR TITLE
chore: cross-platform setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tested in **Shadow Empires**, **Fire and Sand** and **Legends (4)**.
 
 - clone the repo
 - install the dependencies: `npm install`
-- run `npm run setup` (Linux/macOS) or `npm run setup:windows`
+- run `npm run setup`
 - you should probably register new fake account for these manipulations.
 
 ## Config

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "author": "Myhkavko Ivan",
   "scripts": {
-    "setup": "cp .env.example .env && cp src/config/cookie.txt.example src/config/cookie.txt && cp src/config/token.txt.example src/config/token.txt",
-    "setup:windows": "copy .env.example .env & copy src\\config\\cookie.txt.example src\\config\\cookie.txt & copy src\\config\\token.txt.example src\\config\\token.txt",
+    "setup": "node scripts/setup.js",
     "clean": "node src/scripts/cleanData.js",
     "collect": "node src/scripts/collectOasisPosition.js",
     "find": "node src/scripts/findAnimal.js",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,0 +1,16 @@
+const fs = require('node:fs');
+
+const files = [
+  ['.env.example', '.env'],
+  ['src/config/cookie.txt.example', 'src/config/cookie.txt'],
+  ['src/config/token.txt.example', 'src/config/token.txt'],
+];
+
+for (const [src, dst] of files) {
+  if (fs.existsSync(dst)) {
+    console.log(`skip   ${dst} (already exists)`);
+  } else {
+    fs.copyFileSync(src, dst);
+    console.log(`create ${dst}`);
+  }
+}


### PR DESCRIPTION
## Problem

Two separate `setup` / `setup:windows` scripts using shell-specific `cp`/`copy` commands:
- Breaks if run on unexpected shell (Git Bash, WSL, PowerShell)
- Running `npm run setup` a second time silently overwrites `.env` and cookie files with examples, wiping real credentials

## Solution

Single `scripts/setup.js` (plain Node.js, no deps):
- Works on Linux, macOS, Windows — any platform with Node
- Skips files that already exist, prints `skip` or `create` for each
- `setup:windows` removed

## Test

```
$ npm run setup
skip   .env (already exists)
skip   src/config/cookie.txt (already exists)
skip   src/config/token.txt (already exists)
```