### PR TITLE
feat: add HTML report output alongside CSV

### DIFF
--- a/src/scripts/findAnimal.js
+++ b/src/scripts/findAnimal.js
@@ -22,6 +22,84 @@ const readJson = (filePath) => {
 
 const writeJson = (filePath, data) => fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
 
+const buildHtml = (rows, server) => `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Travian Elephants</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; padding: 2rem; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .meta { color: #94a3b8; font-size: 0.875rem; margin-bottom: 1.5rem; }
+    table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+    th { background: #1e293b; color: #94a3b8; font-weight: 600; text-transform: uppercase;
+         font-size: 0.75rem; letter-spacing: 0.05em; padding: 0.75rem 1rem;
+         text-align: left; cursor: pointer; user-select: none; white-space: nowrap; }
+    th:hover { color: #e2e8f0; }
+    th.asc::after  { content: ' ↑'; }
+    th.desc::after { content: ' ↓'; }
+    td { padding: 0.6rem 1rem; border-bottom: 1px solid #1e293b; }
+    tr:hover td { background: #1e293b; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    .elephant { color: #f97316; font-weight: 700; }
+  </style>
+</head>
+<body>
+  <h1>🐘 Travian Elephants</h1>
+  <p class="meta">${server ? `Server: ${server} &nbsp;·&nbsp; ` : ''}Found: ${rows.length} oases &nbsp;·&nbsp; Generated: ${new Date().toLocaleString()}</p>
+  <table id="t">
+    <thead>
+      <tr>
+        <th data-col="0">x</th>
+        <th data-col="1">y</th>
+        <th data-col="2">Elephants</th>
+        <th data-col="3">Other animals</th>
+        <th data-col="4">Crocodiles</th>
+        <th data-col="5">Tigers</th>
+        <th data-col="6">Total animals</th>
+      </tr>
+    </thead>
+    <tbody>
+      ${rows
+        .map(
+          (r) =>
+            `<tr>
+        <td class="num">${r.x}</td>
+        <td class="num">${r.y}</td>
+        <td class="num elephant">${r.elephants}</td>
+        <td class="num">${r.other}</td>
+        <td class="num">${r.crocs}</td>
+        <td class="num">${r.tigers}</td>
+        <td class="num">${r.total}</td>
+      </tr>`,
+        )
+        .join('\n      ')}
+    </tbody>
+  </table>
+  <script>
+    const t = document.getElementById('t');
+    let sortCol = 2, sortDir = -1;
+    t.querySelector('thead').addEventListener('click', (e) => {
+      const th = e.target.closest('th');
+      if (!th) return;
+      const col = +th.dataset.col;
+      sortDir = col === sortCol ? -sortDir : -1;
+      sortCol = col;
+      t.querySelectorAll('th').forEach(h => h.classList.remove('asc','desc'));
+      th.classList.add(sortDir === -1 ? 'desc' : 'asc');
+      const rows = [...t.querySelectorAll('tbody tr')];
+      rows.sort((a, b) => {
+        const v = (r) => +r.cells[col].textContent;
+        return sortDir * (v(b) - v(a));
+      });
+      rows.forEach(r => t.querySelector('tbody').appendChild(r));
+    });
+  </script>
+</body>
+</html>`;
+
 const bar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic);
 
 process.on('SIGINT', () => {
@@ -52,9 +130,12 @@ async function main() {
 
   const date = new Date();
   const fileNameAdd = `${date.toLocaleDateString()}_${date.getTime()}`;
-  const file = `data/elephant_${fileNameAdd}.csv`;
+  const csvFile = `data/elephant_${fileNameAdd}.csv`;
+  const htmlFile = `data/elephant_${fileNameAdd}.html`;
   fs.mkdirSync('data', { recursive: true });
-  fs.writeFileSync(file, CSV_HEADER);
+  fs.writeFileSync(csvFile, CSV_HEADER);
+
+  const results = [];
 
   bar.start(oasisPositions.length, 0);
 
@@ -90,7 +171,18 @@ async function main() {
 
       if (amount > 0) {
         const row = `${x},${y},${amount},${anotherAnimal},${hasCrocodile.length},${hasTiger.length},${totalAnimal}\n`;
-        fs.appendFileSync(file, row);
+        fs.appendFileSync(csvFile, row);
+
+        results.push({
+          x,
+          y,
+          elephants: amount,
+          other: anotherAnimal,
+          crocs: hasCrocodile.length,
+          tigers: hasTiger.length,
+          total: totalAnimal,
+        });
+        fs.writeFileSync(htmlFile, buildHtml(results, config.travian.server));
       }
 
       const tileDetails = $('#tileDetails').first();
@@ -114,7 +206,11 @@ async function main() {
   }
 
   bar.stop();
-  console.log(`${oasisPositions.length} oases processed`);
+  console.log(`${oasisPositions.length} oases processed — ${results.length} with elephants`);
+  if (results.length > 0) {
+    console.log(`Results: ${csvFile}`);
+    console.log(`Report:  ${htmlFile}`);
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary

`npm run find` now writes two files per run:
- `data/elephant_*.csv` — same as before, incremental append
- `data/elephant_*.html` — self-contained dark-theme report, no external deps

## HTML report features

- Sortable columns — click any header to sort ↑/↓ by that column
- Elephants count highlighted in orange
- Shows server name, total found, generation timestamp
- Written incrementally on each elephant found (crash-safe, same as CSV)

## Final output

```
247 oases processed — 12 with elephants
Results: data/elephant_6/11/2026_1749645600000.csv
Report:  data/elephant_6/11/2026_1749645600000.html
```