### PR TITLE
fix: sync engines to Node 22, fix README image refs and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Set correct configuration in:
 
    <img src="public/cookies.png" alt="cookies"/>
 
-4. Insert selected cookie value into `src/config/cookie.text` file
+4. Insert selected cookie value into `src/config/cookie.txt` file
 
 ### MIN_X, MIN_Y
 
@@ -64,13 +64,15 @@ Position of search (your village or cap, probably), calculate distance (for sort
 - `npm run collect` - (collecting oases position) and wait… It will take a lot of time (depends on your config (MIN_X,
   MIN_Y, MAX_X, MAX_Y, DELAY_MIN, DELAY_MAX) etc)
 
-<img src="public/collect.png" alt="collect"/>
+<img src="public/npm-collect.png" alt="collect"/>
 
 - `npm run find` - find animals in oases
 
-<img src="public/find-process.png" alt="find-process"/>
+<img src="public/npm-find.png" alt="npm-find"/>
 
-Result in CSV file: `output/elephant_*.csv`
+Results saved to `output/`:
+- `elephant_*.csv` — raw data
+- `elephant_*.html` — sortable report (open in browser)
 
 |  x  |  y  | Elephant | Another animal | hasCrocodile | hasTiger | totalAnimal |
 | :---: | :---: | :--------: | :--------------: | :------------: | :--------: | :-----------: |

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dotenv": "^17.0.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "author": "Myhkavko Ivan",
   "scripts": {


### PR DESCRIPTION
## Changes

- `engines: ">=20"` → `">=22"` — aligns with `.nvmrc`
- Fix broken image refs: `collect.png` → `npm-collect.png`, `find-process.png` → `npm-find.png` (files were renamed in #45 but README wasn't updated)
- Fix `cookie.text` typo → `cookie.txt`
- Mention HTML report output alongside CSV in README