### PR TITLE
feat: skip village tiles in oasis scan via map.sql

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Context
+
+Glossary for Travian Elephant Finder. Terms only, no implementation.
+
+## Glossary
+
+### Oasis
+A map tile guarded by wild animals; clearing it grants resource bonus + hero XP.
+Oasis positions are **fixed at server start** and never move. A tile is either an
+oasis for the whole server lifetime or never. Animals on it respawn/grow over time,
+but the set of oasis tiles is immutable.
+
+### Village
+A player-founded tile. Villages are founded only on empty valley tiles, never on
+oases. Therefore a tile that holds a village was never an oasis and never will be —
+even if the village is later abandoned or destroyed, that tile stays a valley.
+Consequence: **village tiles can be safely skipped when scanning for oases** — zero
+risk of missing an oasis.
+
+### Occupied oasis
+An oasis annexed to a nearby village. Still an oasis tile, but can't be cleared for
+yourself. Detected live via the `oasis-3` CSS class on the tile popup and excluded
+via `oasis-occupied.json`.
+
+### map.sql
+Public, unauthenticated per-server dump (`<server>/map.sql`). Lists **only occupied
+villages** — no oasis data, no empty tiles (tribe ids 1/2/3/5 only). Live-verified
+on `ts5.x1.europe.travian.com`. Useful here solely to skip village tiles during the
+oasis grid scan.

--- a/src/scripts/collectOasisPosition.js
+++ b/src/scripts/collectOasisPosition.js
@@ -25,6 +25,14 @@ async function main() {
 
   const oasisPosition = readJson(config.jsonFile.oasis);
 
+  let villageSet = new Set();
+  try {
+    villageSet = await travian.fetchVillageCoordinates();
+    console.log(`Loaded ${villageSet.size} village tiles from map.sql to skip`);
+  } catch (error) {
+    console.warn(`map.sql unavailable, scanning without village skip: ${error.message}`);
+  }
+
   const startX = Math.min(+config.coordinates.minX, +config.coordinates.maxX);
   const endX = Math.max(+config.coordinates.minX, +config.coordinates.maxX);
   const startY = Math.min(+config.coordinates.minY, +config.coordinates.maxY);
@@ -35,6 +43,11 @@ async function main() {
 
   for (let x = startX; x < endX; x++) {
     for (let y = startY; y < endY; y++) {
+      if (villageSet.has(`${x},${y}`)) {
+        bar.increment();
+        continue;
+      }
+
       try {
         const response = await withRetry(() => travian.viewTileDetails(x, y));
         const { html } = response.data;

--- a/src/services/travian.js
+++ b/src/services/travian.js
@@ -1,4 +1,5 @@
 const axiosApiInstance = require('#src/libs/axiosApi.js');
+const axiosDefaultInstance = require('#src/libs/axiosDefault.js');
 const config = require('#src/config/index.js');
 
 const Travian = function Travian() {
@@ -24,6 +25,30 @@ const Travian = function Travian() {
     };
 
     return axiosApiInstance.post(`${this.getApiUrl()}/map/tile-details`, sendData);
+  };
+
+  this.getMapSqlUrl = function getMapSqlUrl() {
+    return `${config.travian.server}/map.sql`;
+  };
+
+  // map.sql lists only occupied villages (no oasis/empty tiles). A village tile is
+  // never an oasis, so its coordinates can be skipped during the oasis grid scan.
+  // Pure parser, split out for testing.
+  this.parseVillageCoordinates = function parseVillageCoordinates(sql) {
+    const pattern = /INSERT INTO `x_world` VALUES \(\d+,(-?\d+),(-?\d+),/g;
+    const coordinates = new Set();
+    for (const match of String(sql).matchAll(pattern)) {
+      coordinates.add(`${match[1]},${match[2]}`);
+    }
+    return coordinates;
+  };
+
+  this.fetchVillageCoordinates = async function fetchVillageCoordinates() {
+    const response = await axiosDefaultInstance.get(this.getMapSqlUrl(), {
+      timeout: 30000,
+      responseType: 'text',
+    });
+    return this.parseVillageCoordinates(response.data);
   };
 };
 

--- a/src/services/travian.test.js
+++ b/src/services/travian.test.js
@@ -1,0 +1,29 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const travian = require('#src/services/travian.js');
+
+test('parses village coordinates from map.sql rows', () => {
+  const sql = [
+    "INSERT INTO `x_world` VALUES (144524,-37,-160,3,48513,'FastShield Köyü',13663,'FastShield',0,'',9,NULL,TRUE,NULL,NULL,NULL);",
+    "INSERT INTO `x_world` VALUES (812,-191,198,1,48978,'Base 1',3304,'daartz',246,'OOXX',89,NULL,FALSE,NULL,NULL,NULL);",
+    "INSERT INTO `x_world` VALUES (999001,50,50,5,50001,'Natars village',0,'Natars',0,'',65542,NULL,FALSE,NULL,NULL,NULL);",
+  ].join('\n');
+
+  const coordinates = travian.parseVillageCoordinates(sql);
+
+  assert.equal(coordinates.size, 3);
+  assert.ok(coordinates.has('-37,-160'));
+  assert.ok(coordinates.has('-191,198'));
+  assert.ok(coordinates.has('50,50'));
+});
+
+test('handles positive and negative coordinates and empty input', () => {
+  const sql =
+    "INSERT INTO `x_world` VALUES (1,7,-3,2,100,'x',1,'p',0,'',5,NULL,TRUE,NULL,NULL,NULL);";
+
+  const coordinates = travian.parseVillageCoordinates(sql);
+  assert.ok(coordinates.has('7,-3'));
+
+  assert.equal(travian.parseVillageCoordinates('').size, 0);
+  assert.equal(travian.parseVillageCoordinates('nonsense line').size, 0);
+});


### PR DESCRIPTION
## What

Use the public `map.sql` server dump to skip village tiles during the oasis grid scan in `collectOasisPosition`.

## Why it's safe

Domain invariants (recorded in `CONTEXT.md`):
- Oasis positions are **fixed at server start** and never move.
- Villages are founded only on empty valleys, **never on oases**.

So a tile holding a village can never be (or become) an oasis - even if the village is later abandoned. Skipping village tiles has **zero risk** of missing an oasis.

`map.sql` is public/unauthenticated and lists **only occupied villages** (no oasis/empty tiles) - live-verified on the same server by the sibling `travian-assistant` project. That means its only useful lever here is village-skipping.

## Changes

- `src/services/travian.js` - `getMapSqlUrl()`, `parseVillageCoordinates(sql)` (pure regex parser -> `Set` of `"x,y"`), `fetchVillageCoordinates()` (unauthenticated GET, 30s timeout).
- `src/scripts/collectOasisPosition.js` - build village set at start; `continue` (no HTTP, no delay) on village tiles. Fetch wrapped in `try/catch` -> silent degradation to a full scan if `map.sql` is unavailable.
- `src/services/travian.test.js` - unit tests for the parser.
- `CONTEXT.md` - domain glossary.

## Verification

- `node --test` -> 5/5 green; `biome check` clean.
- Live smoke: real `map.sql` parsed to 13,255 village tiles.
- Real saving on the current box (10x10): 13 village tiles skipped = **-13% requests**.